### PR TITLE
fixes issues with Alpine (busybox)

### DIFF
--- a/PublicGitArchive/examples/java.md
+++ b/PublicGitArchive/examples/java.md
@@ -4,7 +4,7 @@ Downloading all Java repositories
 Execute the following to download all Java siva files to the current directory:
 
 ```bash
-./multitool get-index | tee index.csv | grep -P '[",]Java[",]' | grep -oP '[0-9a-f]{40}\.siva' | ./multitool get-dataset -o .
+./multitool get-index | tee index.csv | grep -P '[",]Java[",]' | grep -oE '[0-9a-f]{40}\.siva' | ./multitool get-dataset -o .
 ```
 
 `index.csv` contains metadata of all the repositories, `grep -P '[",]Java[",]'` it to list only


### PR DESCRIPTION
When using multitool from within an Alpine docker container, -P is not supported.

```grep: unrecognized option: P
 0 / ? BusyBox v1.27.2 (2017-12-12 10:41:50 GMT) multi-call binary.

Usage: grep [-HhnlLoqvsriwFE] [-m N] [-A/B/C N] PATTERN/-e PATTERN.../-f FILE [FILE]...

Search for PATTERN in FILEs (or stdin)

    -H    Add 'filename:' prefix
    -h    Do not add 'filename:' prefix
    -n    Add 'line_no:' prefix
    -l    Show only names of files that match
    -L    Show only names of files that don't match
    -c    Show only count of matching lines
    -o    Show only the matching part of line
    -q    Quiet. Return 0 if PATTERN is found, 1 otherwise
    -v    Select non-matching lines
    -s    Suppress open and read errors
    -r    Recurse
    -i    Ignore case
    -w    Match whole words only
    -x    Match whole lines only
    -F    PATTERN is a literal (not regexp)
    -E    PATTERN is an extended regexp
    -m N    Match up to N times per file
    -A N    Print N lines of trailing context
    -B N    Print N lines of leading context
    -C N    Same as '-A N -B N'
    -e PTRN    Pattern to match
    -f FILE    Read pattern from file
 0 / ?  0s
Read      27 MB
Wrote     64 MB```