### PR TITLE
removed hdfs schema from constructor string

### DIFF
--- a/PublicGitArchive/pga/cmd/filesystem.go
+++ b/PublicGitArchive/pga/cmd/filesystem.go
@@ -37,7 +37,7 @@ func FileSystemFromFlags(flags *pflag.FlagSet) (FileSystem, error) {
 		return localFS(path), nil
 	}
 
-	client, err := hdfs.New(path)
+	client, err := hdfs.New(strings.TrimPrefix(path, "hdfs://"))
 	if err != nil {
 		return nil, fmt.Errorf("could not create HDFS client: %v", err)
 	}


### PR DESCRIPTION
hdfs client fails to get built otherwise

```
# cat /siva.txt | pga get -i -o hdfs://hdfs-namenode-0.hdfs-namenode.default.svc.cluster.local:8020/repositories
Error: could not create HDFS client: no available namenodes: dial tcp: address hdfs://hdfs-namenode-0.hdfs-namenode.default.svc.cluster.local:8020/repositories: too many colons in address
Usage:
  pga get [flags]

Flags:
  -h, --help               help for get
  -j, --jobs int           number of concurrent gets allowed (default 10)
  -l, --lang stringSlice   list of languages that the repositories should have
  -o, --output string      path where the siva files should be stored (default ".")
  -i, --stdin              take list of siva files from standard input
  -u, --url string         regular expression that repo urls need to match

Global Flags:
  -v, --verbose   log more information

could not create HDFS client: no available namenodes: dial tcp: address hdfs://hdfs-namenode-0.hdfs-namenode.default.svc.cluster.local:8020/repositories: too many colons in address