### PR TITLE
pga: safe downloads

### DIFF
--- a/PublicGitArchive/pga/cmd/get.go
+++ b/PublicGitArchive/pga/cmd/get.go
@@ -86,7 +86,9 @@ Alternatively, a list of .siva filenames can be passed through standard input.`,
 	},
 }
 
-func downloadFilenames(dest, source FileSystem, filenames []string, maxDownloads int) error {
+func downloadFilenames(dest, source FileSystem, filenames []string,
+	maxDownloads int) error {
+
 	tokens := make(chan bool, maxDownloads)
 	for i := 0; i < maxDownloads; i++ {
 		tokens <- true

--- a/PublicGitArchive/pga/cmd/list.go
+++ b/PublicGitArchive/pga/cmd/list.go
@@ -24,20 +24,22 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("could not open index file: %v", err)
 		}
-		defer checkClose("index", f, &err)
 
 		index, err := pga.IndexFromCSV(f)
 		if err != nil {
+			_ = f.Close()
 			return err
 		}
 
 		filter, err := filterFromFlags(cmd.Flags())
 		if err != nil {
+			_ = f.Close()
 			return err
 		}
 
 		formatter, err := formatterFromFlags(cmd.Flags())
 		if err != nil {
+			_ = f.Close()
 			return err
 		}
 
@@ -45,6 +47,7 @@ var listCmd = &cobra.Command{
 		for {
 			select {
 			case <-ctx.Done():
+				_ = f.Close()
 				return fmt.Errorf("command canceled")
 			default:
 			}
@@ -53,6 +56,7 @@ var listCmd = &cobra.Command{
 			if err == io.EOF {
 				break
 			} else if err != nil {
+				_ = f.Close()
 				return err
 			}
 
@@ -62,7 +66,8 @@ var listCmd = &cobra.Command{
 				fmt.Print(s)
 			}
 		}
-		return err
+
+		return f.Close()
 	},
 }
 


### PR DESCRIPTION
- pga: download files to temporary file first, fixes #39
- make get/list cancellable: Control+C will make pga to shutdown gracefully and clean up after itself, leaving no traces of temporary downloads