### PR TITLE
pga: avoid warning when local copy doesn't exist

### DIFF
--- a/PublicGitArchive/pga/cmd/cache.go
+++ b/PublicGitArchive/pga/cmd/cache.go
@@ -102,11 +102,9 @@ func upToDate(dest, source FileSystem, name string) bool {
 	if err == nil {
 		return ok
 	}
-	logrus.Warnf("could not check md5 hashes for %s, comparing timestamps instead: %v", name, err)
 
 	localTime, err := dest.ModTime(name)
 	if err != nil {
-		logrus.Warnf("could not check mod time in %s: %v", dest.Abs(name), err)
 		return false
 	}
 
@@ -126,6 +124,7 @@ func matchHash(dest, source FileSystem, name string) (bool, error) {
 	}
 	remoteHash, err := source.MD5(name)
 	if err != nil {
+		logrus.Warnf("could not check md5 hashes for %s: %v", source.Abs(name), err)
 		return false, err
 	}
 	return localHash == remoteHash, nil


### PR DESCRIPTION
Currently running `pga get` provides at least a warning per file that doesn't exist yet.

This is misleading, as not having a file locally that you just asked to download is the normal case.

This change simply removes the warnings so we go from:

```bash
~ ➜  pga get -u /campoy/
WARN[0000] could not check md5 hashes for latest.csv.gz, comparing timestamps instead: could not fetch hash at latest.csv.gz.md5: 404 Not Found
WARN[0002] could not check md5 hashes for siva/latest/1a/1a0377d9d66f8867f8e009c99f53f5e91c6ab0ff.siva, comparing timestamps instead: open siva/latest/1a/1a0377d9d66f8867f8e009c99f53f5e91c6ab0ff.siva: no such file or directory
 0 / 12 [-------------------------------------------------------------------------------------------------------------------------------------------------------------------]   0.00%WARN[0002] could not check mod time in siva/latest/1a/1a0377d9d66f8867f8e009c99f53f5e91c6ab0ff.siva: stat siva/latest/1a/1a0377d9d66f8867f8e009c99f53f5e91c6ab0ff.siva: no such file or directory
WARN[0002] could not check md5 hashes for siva/latest/25/25fc0fc7fd6b19af1cc2717665fe648cc0476f19.siva, comparing timestamps instead: open siva/latest/25/25fc0fc7fd6b19af1cc2717665fe648cc0476f19.siva: no such file or directory
WARN[0002] could not check mod time in siva/latest/25/25fc0fc7fd6b19af1cc2717665fe648cc0476f19.siva: stat siva/latest/25/25fc0fc7fd6b19af1cc2717665fe648cc0476f19.siva: no such file or directory
WARN[0002] could not check md5 hashes for siva/latest/f4/f4f3a888cb237fd5a5bf6a0cb6108ab743eeb45d.siva, comparing timestamps instead: open siva/latest/f4/f4f3a888cb237fd5a5bf6a0cb6108ab743eeb45d.siva: no such file or directory
WARN[0002] could not check mod time in siva/latest/f4/f4f3a888cb237fd5a5bf6a0cb6108ab743eeb45d.siva: stat siva/latest/f4/f4f3a888cb237fd5a5bf6a0cb6108ab743eeb45d.siva: no such file or directory
WARN[0002] could not check md5 hashes for siva/latest/69/69465379ac1ea9386f331bd0148970effd7be754.siva, comparing timestamps instead: open siva/latest/69/69465379ac1ea9386f331bd0148970effd7be754.siva: no such file or directory
WARN[0002] could not check mod time in siva/latest/69/69465379ac1ea9386f331bd0148970effd7be754.siva: stat siva/latest/69/69465379ac1ea9386f331bd0148970effd7be754.siva: no such file or directory
WARN[0002] could not check md5 hashes for siva/latest/35/3581e81ec4b1e9b60cd3de460533e0b3d6316286.siva, comparing timestamps instead: open siva/latest/35/3581e81ec4b1e9b60cd3de460533e0b3d6316286.siva: no such file or directory
WARN[0002] could not check mod time in siva/latest/35/3581e81ec4b1e9b60cd3de460533e0b3d6316286.siva: stat siva/latest/35/3581e81ec4b1e9b60cd3de460533e0b3d6316286.siva: no such file or directory
WARN[0002] could not check md5 hashes for siva/latest/67/679696400bf42d3455adf8bb98b052c4d0c18312.siva, comparing timestamps instead: open siva/latest/67/679696400bf42d3455adf8bb98b052c4d0c18312.siva: no such file or directory
WARN[0002] could not check md5 hashes for siva/latest/fb/fb5644d04154ec5d96e5b5063142476fadc31ad6.siva, comparing timestamps instead: open siva/latest/fb/fb5644d04154ec5d96e5b5063142476fadc31ad6.siva: no such file or directory
WARN[0002] could not check md5 hashes for siva/latest/a8/a8fdea1a7db23bcbfe447d3d27df5f31e821415c.siva, comparing timestamps instead: open siva/latest/a8/a8fdea1a7db23bcbfe447d3d27df5f31e821415c.siva: no such file or directory
WARN[0002] could not check md5 hashes for siva/latest/38/388cbbcd3b247e882962c8894a7fa2340d082a07.siva, comparing timestamps instead: open siva/latest/38/388cbbcd3b247e882962c8894a7fa2340d082a07.siva: no such file or directory
WARN[0002] could not check mod time in siva/latest/38/388cbbcd3b247e882962c8894a7fa2340d082a07.siva: stat siva/latest/38/388cbbcd3b247e882962c8894a7fa2340d082a07.siva: no such file or directory
WARN[0002] could not check mod time in siva/latest/a8/a8fdea1a7db23bcbfe447d3d27df5f31e821415c.siva: stat siva/latest/a8/a8fdea1a7db23bcbfe447d3d27df5f31e821415c.siva: no such file or directory
WARN[0002] could not check mod time in siva/latest/fb/fb5644d04154ec5d96e5b5063142476fadc31ad6.siva: stat siva/latest/fb/fb5644d04154ec5d96e5b5063142476fadc31ad6.siva: no such file or directory
WARN[0002] could not check mod time in siva/latest/67/679696400bf42d3455adf8bb98b052c4d0c18312.siva: stat siva/latest/67/679696400bf42d3455adf8bb98b052c4d0c18312.siva: no such file or directory
WARN[0002] could not check md5 hashes for siva/latest/6d/6dc6c56dec8ca130608ee16db963b99f5fa8d83b.siva, comparing timestamps instead: open siva/latest/6d/6dc6c56dec8ca130608ee16db963b99f5fa8d83b.siva: no such file or directory
WARN[0002] could not check mod time in siva/latest/6d/6dc6c56dec8ca130608ee16db963b99f5fa8d83b.siva: stat siva/latest/6d/6dc6c56dec8ca130608ee16db963b99f5fa8d83b.siva: no such file or directory
 0 / 12 [-------------------------------------------------------------------------------------------------------------------------------------------------------------------]   0.00%WARN[0002] could not check md5 hashes for siva/latest/d6/d6ef7718f66e80e47381312b5202e2af5102f15b.siva, comparing timestamps instead: open siva/latest/d6/d6ef7718f66e80e47381312b5202e2af5102f15b.siva: no such file or directory
 1 / 12 [=============>--------------------------------------------------------------------------------------------------------------------------------------------------]   8.33% 4sWARN[0002] could not check mod time in siva/latest/d6/d6ef7718f66e80e47381312b5202e2af5102f15b.siva: stat siva/latest/d6/d6ef7718f66e80e47381312b5202e2af5102f15b.siva: no such file or directory
 2 / 12 [==========================>-------------------------------------------------------------------------------------------------------------------------------------]  16.67% 2sWARN[0003] could not check md5 hashes for siva/latest/a6/a616018354ba5c883af1799cc3591c3483f7a172.siva, comparing timestamps instead: open siva/latest/a6/a616018354ba5c883af1799cc3591c3483f7a172.siva: no such file or directory
WARN[0003] could not check mod time in siva/latest/a6/a616018354ba5c883af1799cc3591c3483f7a172.siva: stat siva/latest/a6/a616018354ba5c883af1799cc3591c3483f7a172.siva: no such file or directory
 9 / 12 [==========================================================================================================================>----------------------------------------]  75.00%
...
```

to:

```bash
13:41 ~ ➜  pga get -u /campoy/
WARN[0000] could not check md5 hashes for http://pga.sourced.tech/csv/latest.csv.gz: could not fetch hash at latest.csv.gz.md5: 404 Not Found
 12 / 12 [==================================================================================================================================================================] 100.00%
```