### PR TITLE
[PGA] add pga-create repack command

### DIFF
--- a/PublicGitArchive/pga-create/README.md
+++ b/PublicGitArchive/pga-create/README.md
@@ -4,6 +4,7 @@ Tool to create the PGA dataset.
 
 The following commands exist:
 
+* `repack` - downloads latest GHTorrent MySQL dump and repacks it only with the required files (optional step).
 * `discover` - extract the needed information from GHTorrent MySQL dump on the fly. Requires only 1.5 GB of storage.
 * `select` - compile the list of repositories to clone according to various filters, such as stars or languages.
 * `index` - create the index

--- a/PublicGitArchive/pga-create/cmd/pga-create/main.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/main.go
@@ -11,6 +11,14 @@ var parser = flags.NewParser(nil, flags.Default)
 
 func init() {
 	if _, err := parser.AddCommand(
+		"repack",
+		"Repack GHTorrent MySQL dump",
+		"Repack GHTorrent MySQL dump",
+		&repackCommand{}); err != nil {
+		panic(err)
+	}
+
+	if _, err := parser.AddCommand(
 		"discover",
 		"Fetch the GHTorrent MySQL dump and extract the list of repositories and the stars per repository.",
 		"Fetch the GHTorrent MySQL dump and extract the list of repositories and the stars per repository.",

--- a/PublicGitArchive/pga-create/cmd/pga-create/repack.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/repack.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/briandowns/spinner"
+	humanize "github.com/dustin/go-humanize"
+)
+
+type repackCommand struct {
+	URL    string `short:"l" long:"url" description:"Link to GHTorrent MySQL dump in tar.gz format. If \"-\", stdin is read. If empty (default), find the most recent dump at GHTORRENT_MYSQL ?= http://ghtorrent-downloads.ewi.tudelft.nl/mysql/."`
+	Output string `short:"o" long:"output" description:"output file"`
+}
+
+func (c *repackCommand) Execute(args []string) error {
+	repack(c.URL, c.Output)
+
+	return nil
+}
+
+func repack(url, output string) {
+	startTime := time.Now()
+	spin := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+	spin.Start()
+	defer spin.Stop()
+
+	var inputFile io.Reader
+	if url == "-" {
+		inputFile = os.Stdin
+	} else {
+		if url == "" {
+			envURL := os.Getenv("GHTORRENT_MYSQL")
+			if envURL == "" {
+				envURL = defaultGhtorrentMySQL
+			}
+			spin.Suffix = " " + envURL
+			url = findMostRecentMySQLDump(envURL)
+			fmt.Printf("\r>> %s\n", url)
+			spin.Suffix = " connecting..."
+		}
+		response, err := http.Get(url)
+		if err != nil {
+			fail("starting the download of "+url, err)
+		}
+		inputFile = response.Body
+		defer response.Body.Close()
+	}
+	var totalRead int64
+	inputFile = trackingReader{RealReader: inputFile, Callback: func(n int) {
+		totalRead += int64(n)
+		if totalRead%3 == 0 {
+			// supposing that mod 3 is random, this is a quick and dirty way to (/ 3) updates.
+			spin.Suffix = fmt.Sprintf(" %s", humanize.Bytes(uint64(totalRead)))
+		}
+	}}
+	gzf, err := gzip.NewReader(inputFile)
+	if err != nil {
+		fail("opening gzip stream", err)
+	}
+	defer gzf.Close()
+	tarf := tar.NewReader(gzf)
+	processed := int64(0)
+
+	outf, err := createOutput(output)
+	if err != nil {
+		fail("creating output file", err)
+	}
+	gzw := gzip.NewWriter(outf)
+	tarw := tar.NewWriter(gzw)
+
+	numTasks := 3
+	status := 0
+	i := 0
+	for header, err := tarf.Next(); err != io.EOF; header, err = tarf.Next() {
+		if err != nil {
+			fail("reading tar.gz", err)
+		}
+		i++
+		processed += header.Size
+		isRelevant := strings.HasSuffix(header.Name, "watchers.csv") ||
+			strings.HasSuffix(header.Name, "projects.csv") ||
+			strings.HasSuffix(header.Name, "project_languages.csv")
+		mark := " "
+		if isRelevant {
+			mark = ">"
+		}
+		strSize := humanize.Bytes(uint64(header.Size))
+		if strings.HasSuffix(strSize, " B") {
+			strSize += " "
+		}
+		if i == 1 {
+			fmt.Print("\r", strings.Repeat(" ", 80))
+		}
+		fmt.Printf("\r%s %2d  %7s  %s\n", mark, i, strSize, header.Name)
+		if isRelevant {
+			if err := tarw.WriteHeader(header); err != nil {
+				fail("writing tar header", err)
+			}
+
+			if _, err := io.Copy(tarw, tarf); err != nil {
+				fail("writing tar file", err)
+			}
+
+			status++
+		}
+		if status == numTasks {
+			break
+		}
+	}
+
+	if err := tarw.Close(); err != nil {
+		fail("closing output tar file", err)
+	}
+
+	if err := gzw.Close(); err != nil {
+		fail("closing output gz file", err)
+	}
+
+	fmt.Printf("\nRead      %s\nProcessed %s\nElapsed   %s\n",
+		humanize.Bytes(uint64(totalRead)), humanize.Bytes(uint64(processed)), time.Since(startTime))
+
+	if err := outf.Close(); err != nil {
+		fail("closing output file", err)
+	}
+}
+
+func createOutput(f string) (io.WriteCloser, error) {
+	if f == "-" {
+		return os.Stdout, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(f), os.FileMode(0755)); err != nil {
+		return nil, err
+	}
+
+	return os.Create(f)
+}


### PR DESCRIPTION
Add a `pga-create repack` command. This downloads latest GHTorrent MySQL dump and repacks it on the fly to store a local copy without the files that are not needed. This is particularly useful during development of `pga-create`, since the repacked version can be processed 10-20 minutes, while processing the original GHTorrent MySQL dump takes hours.

This PR depends on https://github.com/src-d/datasets/pull/78 (check only last commit) and do not merge.