### PR TITLE
[PGA] simplify pga-create usage

### DIFF
--- a/PublicGitArchive/pga-create/README.md
+++ b/PublicGitArchive/pga-create/README.md
@@ -27,8 +27,8 @@ repositories on GitHub with ≥50 stars, which is equivalent to
 the following commands which generate `list.txt`:
 
 ```bash
-pga-create discover -s stars.txt -r repos.txt.gz
-pga-create select -s stars.txt -r repos.txt.gz -m 50 > list.txt
+pga-create discover
+pga-create select -m 50 > repository_list.txt
 ```
 
 ### Cloning repositories
@@ -41,7 +41,7 @@ In the first terminal execute
 
 ```
 borges init
-borges producer --source=file --file list.txt
+borges producer --source=file --file repository_list.txt
 ```
 
 In the second terminal execute
@@ -76,4 +76,3 @@ pga-create set-forks
 ```
 
 This will take `result.csv` and add the forks to it, resulting in a `result_forks.csv` file with the same data you had in the original CSV, only with the forks added.
-

--- a/PublicGitArchive/pga-create/cmd/pga-create/discover.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/discover.go
@@ -27,9 +27,9 @@ const (
 
 type discoverCommand struct {
 	URL          string `short:"l" long:"url" description:"Link to GHTorrent MySQL dump in tar.gz format. If empty (default), read from stdin if available or find the most recent dump at GHTORRENT_MYSQL ?= http://ghtorrent-downloads.ewi.tudelft.nl/mysql/."`
-	Stars        string `short:"s" long:"stars" required:"true" description:"Output path for the file with the numbers of stars per repository."`
-	Languages    string `short:"g" long:"languages" description:"Output path for the gzipped file with the mapping between languages and repositories. May be empty - will be skipped then."`
-	Repositories string `short:"r" long:"repositories" required:"true" description:"Output path for the gzipped file with the repository names and identifiers."`
+	Stars        string `short:"s" long:"stars" default:"data/stars.gz" description:"Output path for the file with the numbers of stars per repository."`
+	Languages    string `short:"g" long:"languages" default:"data/languages.gz" description:"Output path for the gzipped file with the mapping between languages and repositories. May be empty - will be skipped then."`
+	Repositories string `short:"r" long:"repositories" default:"data/repositories.gz" description:"Output path for the gzipped file with the repository names and identifiers."`
 }
 
 func (c *discoverCommand) Execute(args []string) error {

--- a/PublicGitArchive/pga-create/cmd/pga-create/discover.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/discover.go
@@ -26,7 +26,7 @@ const (
 )
 
 type discoverCommand struct {
-	URL          string `short:"l" long:"url" description:"Link to GHTorrent MySQL dump in tar.gz format. If \"-\", stdin is read. If empty (default), find the most recent dump at GHTORRENT_MYSQL ?= http://ghtorrent-downloads.ewi.tudelft.nl/mysql/."`
+	URL          string `short:"l" long:"url" description:"Link to GHTorrent MySQL dump in tar.gz format. If empty (default), read from stdin if available or find the most recent dump at GHTORRENT_MYSQL ?= http://ghtorrent-downloads.ewi.tudelft.nl/mysql/."`
 	Stars        string `short:"s" long:"stars" required:"true" description:"Output path for the file with the numbers of stars per repository."`
 	Languages    string `short:"g" long:"languages" description:"Output path for the gzipped file with the mapping between languages and repositories. May be empty - will be skipped then."`
 	Repositories string `short:"r" long:"repositories" required:"true" description:"Output path for the gzipped file with the repository names and identifiers."`
@@ -51,7 +51,7 @@ type discoveryParameters struct {
 }
 
 type trackingReader struct {
-	RealReader io.Reader
+	RealReader io.ReadCloser
 	Callback   func(n int)
 }
 
@@ -59,6 +59,10 @@ func (reader trackingReader) Read(p []byte) (n int, err error) {
 	n, err = reader.RealReader.Read(p)
 	reader.Callback(n)
 	return n, err
+}
+
+func (reader trackingReader) Close() error {
+	return reader.RealReader.Close()
 }
 
 func reduceWatchers(stream io.Reader) map[uint32]uint32 {
@@ -274,27 +278,10 @@ func discoverRepos(params discoveryParameters) {
 	spin := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	spin.Start()
 	defer spin.Stop()
-	var inputFile io.Reader
-	if params.URL == "-" {
-		inputFile = os.Stdin
-	} else {
-		if params.URL == "" {
-			envURL := os.Getenv("GHTORRENT_MYSQL")
-			if envURL == "" {
-				envURL = defaultGhtorrentMySQL
-			}
-			spin.Suffix = " " + envURL
-			params.URL = findMostRecentMySQLDump(envURL)
-			fmt.Printf("\r>> %s\n", params.URL)
-			spin.Suffix = " connecting..."
-		}
-		response, err := http.Get(params.URL)
-		if err != nil {
-			fail("starting the download of "+params.URL, err)
-		}
-		inputFile = response.Body
-		defer response.Body.Close()
-	}
+
+	inputFile := dumpReader(params.URL, spin)
+	defer inputFile.Close()
+
 	var totalRead int64
 	inputFile = trackingReader{RealReader: inputFile, Callback: func(n int) {
 		totalRead += int64(n)
@@ -358,4 +345,34 @@ func discoverRepos(params discoveryParameters) {
 	}
 	fmt.Printf("\nRead      %s\nProcessed %s\nElapsed   %s\n",
 		humanize.Bytes(uint64(totalRead)), humanize.Bytes(uint64(processed)), time.Since(startTime))
+}
+
+func dumpReader(url string, spin *spinner.Spinner) io.ReadCloser {
+	if url == "" {
+		fi, err := os.Stdin.Stat()
+		if err != nil {
+			fail("checking stat on stdin", err)
+		}
+
+		if fi.Mode()&os.ModeNamedPipe != 0 {
+			return os.Stdin
+		}
+
+		envURL := os.Getenv("GHTORRENT_MYSQL")
+		if envURL == "" {
+			envURL = defaultGhtorrentMySQL
+		}
+
+		spin.Suffix = " " + envURL
+		url = findMostRecentMySQLDump(envURL)
+	}
+
+	fmt.Printf("\r>> %s\n", url)
+	spin.Suffix = " connecting..."
+	response, err := http.Get(url)
+	if err != nil {
+		fail("starting the download of "+url, err)
+	}
+
+	return response.Body
 }

--- a/PublicGitArchive/pga-create/cmd/pga-create/discover.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/discover.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -256,6 +257,20 @@ func findMostRecentMySQLDump(root string) string {
 
 func discoverRepos(params discoveryParameters) {
 	startTime := time.Now()
+
+	for _, p := range []string{
+		params.ReposPath,
+		params.StarsPath,
+		params.LanguagesPath} {
+		if p == "" {
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(p), os.FileMode(0755)); err != nil {
+			fail("could not create directory", err)
+		}
+	}
+
 	spin := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
 	spin.Start()
 	defer spin.Stop()

--- a/PublicGitArchive/pga-create/cmd/pga-create/indexer.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/indexer.go
@@ -13,7 +13,7 @@ import (
 )
 
 type indexCommand struct {
-	Output    string `short:"o" long:"output" default:"result.csv" description:"csv file path with the results"`
+	Output    string `short:"o" long:"output" default:"data/index.csv" description:"csv file path with the results"`
 	Debug     bool   `long:"debug" description:"show debug logs"`
 	LogFile   string `long:"logfile" description:"write logs to file"`
 	Limit     uint64 `long:"limit" description:"max number of repositories to process"`

--- a/PublicGitArchive/pga-create/cmd/pga-create/repack.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/repack.go
@@ -16,7 +16,7 @@ import (
 
 type repackCommand struct {
 	URL    string `short:"l" long:"url" description:"Link to GHTorrent MySQL dump in tar.gz format. If empty (default), read from stdin if possible or find the most recent dump at GHTORRENT_MYSQL ?= http://ghtorrent-downloads.ewi.tudelft.nl/mysql/."`
-	Output string `short:"o" long:"output" description:"output file"`
+	Output string `short:"o" long:"output" required:"true" description:"output file"`
 }
 
 func (c *repackCommand) Execute(args []string) error {

--- a/PublicGitArchive/pga-create/cmd/pga-create/select.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/select.go
@@ -15,9 +15,9 @@ import (
 )
 
 type selectCommand struct {
-	Stars           string `short:"s" long:"stars" required:"true" description:"Input path for the file with the numbers of stars per repository."`
-	Languages       string `short:"g" long:"languages" description:"Input path for the gzipped file with the mapping between languages and repositories."`
-	Repositories    string `short:"r" long:"repositories" required:"true" description:"Input path for the gzipped file with the repository names and identifiers."`
+	Stars           string `short:"s" long:"stars" default:"data/stars.gz" description:"Input path for the file with the numbers of stars per repository."`
+	Languages       string `short:"g" long:"languages" default:"data/languages.gz" description:"Input path for the gzipped file with the mapping between languages and repositories."`
+	Repositories    string `short:"r" long:"repositories" default:"data/repositories.gz" description:"Input path for the gzipped file with the repository names and identifiers."`
 	MinStars        int    `short:"m" long:"min-stars" description:"Minimum number of stars."`
 	Max             int    `short:"n" long:"max" default:"-1" description:"Maximum number of top-starred repositories to clone. -1 means unlimited. Language filter is applied before."`
 	FilterLanguages string `short:"l" long:"filter-languages" description:"Comma separated list of languages."`


### PR DESCRIPTION
- create required directories upfront, this avoids errors after expensive processing is finished and results are written.
- autodetect if stdin is used (`--url=-` not required anymore to read from stdin).
-  add more default arguments (`--repositories`, `--stars` and `--languages` are not needed anymore unless specific paths are needed).
