### PR TITLE
Supress md5 logs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
   - 1.11.x
 
 before_install:
-  - go get -v github.com/golang/lint/golint
+  - go get -v -u golang.org/x/lint/golint
 
 script:
   - go vet ./...

--- a/PublicGitArchive/pga/cmd/cache.go
+++ b/PublicGitArchive/pga/cmd/cache.go
@@ -98,9 +98,8 @@ func cancelableCopy(ctx context.Context, dst io.Writer, src io.Reader) (int64, e
 }
 
 func upToDate(dest, source FileSystem, name string) bool {
-	ok, err := matchHash(dest, source, name)
-	if err == nil {
-		return ok
+	if matchHash(dest, source, name) {
+		return true
 	}
 
 	localTime, err := dest.ModTime(name)
@@ -117,17 +116,16 @@ func upToDate(dest, source FileSystem, name string) bool {
 	return !localTime.IsZero() && !remoteTime.IsZero() && remoteTime.Before(localTime)
 }
 
-func matchHash(dest, source FileSystem, name string) (bool, error) {
+func matchHash(dest, source FileSystem, name string) bool {
 	localHash, err := dest.MD5(name)
 	if err != nil {
-		return false, err
+		return false
 	}
 	remoteHash, err := source.MD5(name)
 	if err != nil {
-		logrus.Warnf("could not check md5 hashes for %s: %v", source.Abs(name), err)
-		return false, err
+		return false
 	}
-	return localHash == remoteHash, nil
+	return localHash == remoteHash
 }
 
 func getIndex(ctx context.Context) (io.ReadCloser, error) {


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>

If the only reason why we try to download MD5 is to check if the file is up to date (nothing else) then lets make `matchHash` just as a boolean function, instead of returning boolean and an error (it's like a fuzzy logic). 
At least it will suppress the annoying warning.
I know it may look like not a right fix, but so far we don't verify hashes (saying it's middleman hack or whatever). We just say latest or not and in case of false we double check it. So logging missed md5 as a warning is too annoying IMO.