### PR TITLE
update lint repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
   - 1.11.x
 
 before_install:
-  - go get -v github.com/golang/lint/golint
+  - go get -v -u golang.org/x/lint/golint
 
 script:
   - go vet ./...


### PR DESCRIPTION
Signed-off-by: kuba-- <kuba@sourced.tech>
Right now travis build fails because could `go get` go-lint repo.