### PR TITLE
Add stars field to pga index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea
+
+**/.ci
+**/build
+

--- a/PublicGitArchive/pga-create/README.md
+++ b/PublicGitArchive/pga-create/README.md
@@ -58,14 +58,21 @@ To process the downloaded repositories you will need the `pga-create index` comm
 Same environment variables as in borges can be used to configure the database access.
 
 ```
-pga-create index -debug -logfile=borges-indexer.log
+pga-create index --debug --logfile=pga-create-index.log
 ```
 
-The arguments accepted by borges indexer are the following:
-* `-debug`: print more verbose logs that can be used for debugging purposes
-* `-logfile=<LOGFILE PATH>`: path to the file where logs will be written
-* `-limit=N`: max number of repositories to process (useful for batch processing)
-* `-offset=N`: skip the first N repositories (useful for batch processing)
+The options accepted by `pga-create index` are the following:
+```
+-o, --output=   csv file path with the results (default: data/index.csv)
+--debug         show debug logs
+--logfile=      write logs to file
+--limit=        max number of repositories to process
+--offset=       skip initial n repositories
+--workers=      number of workers to use (defaults to number of CPUs)
+--repos-file=   path to a file with a repository per line, only those will be processed
+-s, --stars=    input path for the file with the numbers of stars per repository (default: data/stars.gz)
+-r, --repositories= input path for the gzipped file with the repository names and identifiers (default: data/repositories.gz)
+```
 
 **NOTE:** this spawns as many workers as CPUs are available in the machine. Take into account that some repositories may be considerably large and this process may take a very big amount of memory in the machine.
 

--- a/PublicGitArchive/pga-create/cmd/pga-create/indexer.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/indexer.go
@@ -20,8 +20,8 @@ type indexCommand struct {
 	Offset       uint64 `long:"offset" description:"skip initial n repositories"`
 	Workers      int    `long:"workers" description:"number of workers to use (defaults to number of CPUs)"`
 	ReposFile    string `long:"repos-file" description:"path to a file with a repository per line, only those will be processed"`
-	Stars        string `short:"s" long:"stars" default:"data/stars.gz" description:"Input path for the file with the numbers of stars per repository."`
-	Repositories string `short:"r" long:"repositories" default:"data/repositories.gz" description:"Input path for the gzipped file with the repository names and identifiers."`
+	Stars        string `short:"s" long:"stars" default:"data/stars.gz" description:"input path for the file with the numbers of stars per repository"`
+	Repositories string `short:"r" long:"repositories" default:"data/repositories.gz" description:"input path for the gzipped file with the repository names and identifiers"`
 }
 
 func (c *indexCommand) Execute(args []string) error {

--- a/PublicGitArchive/pga-create/cmd/pga-create/indexer.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/indexer.go
@@ -13,13 +13,15 @@ import (
 )
 
 type indexCommand struct {
-	Output    string `short:"o" long:"output" default:"data/index.csv" description:"csv file path with the results"`
-	Debug     bool   `long:"debug" description:"show debug logs"`
-	LogFile   string `long:"logfile" description:"write logs to file"`
-	Limit     uint64 `long:"limit" description:"max number of repositories to process"`
-	Offset    uint64 `long:"offset" description:"skip initial n repositories"`
-	Workers   int    `long:"workers" description:"number of workers to use (defaults to number of CPUs)"`
-	ReposFile string `long:"repos-file" description:"path to a file with a repository per line, only those will be processed"`
+	Output       string `short:"o" long:"output" default:"data/index.csv" description:"csv file path with the results"`
+	Debug        bool   `long:"debug" description:"show debug logs"`
+	LogFile      string `long:"logfile" description:"write logs to file"`
+	Limit        uint64 `long:"limit" description:"max number of repositories to process"`
+	Offset       uint64 `long:"offset" description:"skip initial n repositories"`
+	Workers      int    `long:"workers" description:"number of workers to use (defaults to number of CPUs)"`
+	ReposFile    string `long:"repos-file" description:"path to a file with a repository per line, only those will be processed"`
+	Stars        string `short:"s" long:"stars" default:"data/stars.gz" description:"Input path for the file with the numbers of stars per repository."`
+	Repositories string `short:"r" long:"repositories" default:"data/repositories.gz" description:"Input path for the gzipped file with the repository names and identifiers."`
 }
 
 func (c *indexCommand) Execute(args []string) error {
@@ -71,6 +73,8 @@ func (c *indexCommand) Execute(args []string) error {
 		c.Limit,
 		c.Offset,
 		repos,
+		c.Repositories,
+		c.Stars,
 	)
 
 	return nil

--- a/PublicGitArchive/pga-create/index.go
+++ b/PublicGitArchive/pga-create/index.go
@@ -1,9 +1,14 @@
 package indexer
 
 import (
+	"bufio"
+	"compress/gzip"
 	"encoding/csv"
+	"fmt"
+	"io"
 	"os"
 	"os/signal"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/src-d/core-retrieval.v0/model"
@@ -21,6 +26,8 @@ func Index(
 	limit uint64,
 	offset uint64,
 	list []string,
+	reposIDPath string,
+	starsPath string,
 ) {
 	f, err := createOutputFile(outputFile)
 	if err != nil {
@@ -40,9 +47,14 @@ func Index(
 		logrus.WithField("err", err).Fatal("unable to get result set")
 	}
 
+	stars, err := getRepoToStars(reposIDPath, starsPath, list)
+	if err != nil {
+		logrus.WithField("err", err).Fatal("unable to get repositories' stars")
+	}
+
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt)
-	repos := processRepos(workers, txer, rs)
+	repos := processRepos(workers, txer, rs, stars)
 	var processed int
 	for {
 		select {
@@ -125,4 +137,167 @@ func getResultSet(
 	}
 
 	return rs, total, nil
+}
+
+func getRepoToStars(reposIDPath, starsPath string, list []string) (map[string]int, error) {
+	r, err := os.Open(reposIDPath)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	s, err := os.Open(starsPath)
+	if err != nil {
+		return nil, err
+	}
+	defer s.Close()
+
+	rgz, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	defer rgz.Close()
+
+	sgz, err := gzip.NewReader(s)
+	if err != nil {
+		return nil, err
+	}
+	defer sgz.Close()
+
+	var repoSet map[string]struct{}
+	if len(list) != 0 {
+		repoSet = reposListToSet(list)
+	}
+
+	repos, err := buildIDToRepo(rgz, repoSet)
+	if err != nil {
+		return nil, err
+	}
+
+	var idSet map[int]struct{}
+	if len(list) != 0 {
+		idSet = make(map[int]struct{}, len(repos))
+		for id := range repos {
+			idSet[id] = struct{}{}
+		}
+	}
+
+	stars, err := buildIDToStars(sgz, idSet)
+	if err != nil {
+		return nil, err
+	}
+
+	repoStars := make(map[string]int)
+	for id, repo := range repos {
+		// if id is not present in stars map that repo has no stars.
+		n, ok := stars[id]
+		if ok {
+			repoStars[repo] = n
+		}
+	}
+
+	return repoStars, nil
+}
+
+func reposListToSet(list []string) map[string]struct{} {
+	if len(list) == 0 {
+		return nil
+	}
+
+	repos := make(map[string]struct{}, len(list))
+	for _, url := range list {
+		name := trimRepoURL(url)
+		repos[name] = struct{}{}
+	}
+
+	return repos
+}
+
+func trimRepoURL(url string) string {
+	const (
+		HTTPprefix = "https://github.com/"
+		SSHprefix  = "git://github.com/"
+		suffix     = ".git"
+	)
+
+	var repo string
+	if strings.HasPrefix(url, HTTPprefix) {
+		repo = strings.TrimPrefix(url, HTTPprefix)
+	} else if strings.HasPrefix(url, SSHprefix) {
+		repo = strings.TrimPrefix(url, SSHprefix)
+		repo = strings.TrimSuffix(repo, suffix)
+	}
+
+	return repo
+}
+
+func buildIDToRepo(r io.Reader, repoSet map[string]struct{}) (map[int]string, error) {
+	repos := make(map[int]string)
+	scanner := bufio.NewScanner(r)
+	var count int
+	for scanner.Scan() {
+		var (
+			id   int
+			name string
+		)
+
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		if _, err := fmt.Sscan(line, &id, &name); err != nil {
+			return nil, err
+		}
+
+		_, ok := repoSet[name]
+		if len(repoSet) == 0 || ok {
+			repos[id] = name
+			count++
+		}
+
+		if len(repoSet) != 0 && count >= len(repoSet) {
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return repos, nil
+}
+
+func buildIDToStars(r io.Reader, idSet map[int]struct{}) (map[int]int, error) {
+	stars := make(map[int]int)
+	scanner := bufio.NewScanner(r)
+	var count int
+	for scanner.Scan() {
+		var id, nstar int
+
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		if _, err := fmt.Sscan(line, &id, &nstar); err != nil {
+			return nil, err
+		}
+
+		_, ok := idSet[id]
+		if len(idSet) == 0 || ok {
+			stars[id] = nstar
+			count++
+		}
+
+		if len(idSet) != 0 && count >= len(idSet) {
+			break
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return stars, nil
 }

--- a/PublicGitArchive/pga/cmd/cache.go
+++ b/PublicGitArchive/pga/cmd/cache.go
@@ -144,5 +144,6 @@ func getIndex(ctx context.Context) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return gzip.NewReader(f)
 }

--- a/PublicGitArchive/pga/pga/pga.go
+++ b/PublicGitArchive/pga/pga/pga.go
@@ -30,6 +30,7 @@ type Repository struct {
 	Commits  int64 `json:"commitsCount"`  // Number of commits in the repository.
 	Branches int64 `json:"branchesCount"` // Number of branches in the repository.
 	Forks    int64 `json:"forkCount"`     // Number of forks of this repository.
+	Stars    int64 `json:"stars"`         // Number of stars of this repository.
 }
 
 // CSVHeaders are the headers expected for the CSV formatted index.
@@ -54,6 +55,7 @@ const (
 	headerCodeLinesCount
 	headerCommentLinesCount
 	headerLicense
+	headerStars
 )
 
 var csvHeaders = []string{
@@ -71,6 +73,7 @@ var csvHeaders = []string{
 	headerCodeLinesCount:    "CODE_LINES_COUNT",
 	headerCommentLinesCount: "COMMENT_LINES_COUNT",
 	headerLicense:           "LICENSE",
+	headerStars:             "STARS",
 }
 
 // RepositoryFromCSV returns a repository given a CSV representation of it.
@@ -91,6 +94,7 @@ func RepositoryFromCSV(cols []string) (repo *Repository, err error) {
 		LanguagesCodeLines:    p.intList(headerCodeLinesCount),
 		LanguagesCommentLines: p.intList(headerCommentLinesCount),
 		License:               cols[headerLicense],
+		Stars:                 p.int(headerStars),
 	}, p.err
 }
 
@@ -111,6 +115,7 @@ func (r *Repository) ToCSV() []string {
 		headerCodeLinesCount:    formatIntList(r.LanguagesCodeLines),
 		headerCommentLinesCount: formatIntList(r.LanguagesCommentLines),
 		headerLicense:           r.License,
+		headerStars:             formatInt(r.Stars),
 	}
 }
 


### PR DESCRIPTION
Closes #43 

Now the index has a new field `STARS` containing the number of starts for each repository.
```csv
URL,SIVA_FILENAMES,FILE_COUNT,LANGS,LANGS_BYTE_COUNT,LANGS_LINES_COUNT,LANGS_FILES_COUNT,COMMITS_COUNT,BRANCHES_COUNT,FORK_COUNT,EMPTY_LINES_COUNT,CODE_LINES_COUNT,COMMENT_LINES_COUNT,LICENSE,STARS
git://github.com/FreeCodeCamp/FreeCodeCamp.git,7a80dfe1684664cefd2923bdbb329dcb9a48dc4f.siva,36547,"CSS,EJS,HTML,INI,JSON,JSON5,JavaScript,Less,Markdown,Pug,SVG,TOML,Text,XML,YAML","38234,2164,712,413,5710986,1155,4084308,33,70728961,14724,12177,583,72,387,1964","2322,59,21,29,155975,61,36225,2,1585217,264,89,12,4,13,115","48,5,2,2,418,2,384,1,35622,5,3,1,1,1,4",21123,27808,0,"242,0,3,0,3,0,3683,0,432408,0,0,1,0,0,14","2022,0,17,0,155879,0,30510,0,1125623,0,0,4,0,12,83","20,0,0,0,0,0,1655,0,0,0,0,7,0,0,14","BSD-3-Clause:0.991,BSD-3-Clause-Clear:0.853,BSD-3-Clause-No-Nuclear-License-2014:0.783,BSD-4-Clause:0.838,BSD-Source-Code:0.831",230986
```

And the `pga` command can read it:
```
$ pga list -f json | jq

{
  "url": "git://github.com/FreeCodeCamp/FreeCodeCamp.git",
  "sivaFilenames": [
    "7a80dfe1684664cefd2923bdbb329dcb9a48dc4f.siva"
  ],
  "license": "BSD-3-Clause:0.991,BSD-3-Clause-Clear:0.853,BSD-3-Clause-No-Nuclear-License-2014:0.783,BSD-4-Clause:0.838,BSD-Source-Code:0.831",
  "langs": [
    "CSS",
    "EJS",
    "HTML",
    "INI",
    "JSON",
    "JSON5",
    "JavaScript",
    "Less",
    "Markdown",
    "Pug",
    "SVG",
    "TOML",
    "Text",
    "XML",
    "YAML"
  ],
  "langsByteCount": [
    38234,
    2164,
    712,
    413,
    5710986,
    1155,
    4084308,
    33,
    70728961,
    14724,
    12177,
    583,
    72,
    387,
    1964
  ],
  "langsLinesCount": [
    2322,
    59,
    21,
    29,
    155975,
    61,
    36225,
    2,
    1585217,
    264,
    89,
    12,
    4,
    13,
    115
  ],
  "langsFilesCount": [
    48,
    5,
    2,
    2,
    418,
    2,
    384,
    1,
    35622,
    5,
    3,
    1,
    1,
    1,
    4
  ],
  "emptyLinesCount": [
    242,
    0,
    3,
    0,
    3,
    0,
    3683,
    0,
    432408,
    0,
    0,
    1,
    0,
    0,
    14
  ],
  "codeLinesCount": [
    2022,
    0,
    17,
    0,
    155879,
    0,
    30510,
    0,
    1125623,
    0,
    0,
    4,
    0,
    12,
    83
  ],
  "commentLinesCount": [
    20,
    0,
    0,
    0,
    0,
    0,
    1655,
    0,
    0,
    0,
    0,
    7,
    0,
    0,
    14
  ],
  "fileCount": 36547,
  "commitsCount": 21123,
  "branchesCount": 27808,
  "forkCount": 0,
  "stars": 230986
}

```
