### PR TITLE
pga: add flag to the command to select pga version to download

### DIFF
--- a/PublicGitArchive/pga/cmd/cache.go
+++ b/PublicGitArchive/pga/cmd/cache.go
@@ -11,10 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-const (
-	indexURL  = "http://pga.sourced.tech/csv"
-	indexName = "latest.csv.gz"
-)
+const indexURL = "http://pga.sourced.tech/csv"
 
 // updateCache checks whether a new version of the file in url exists and downloads it
 // to dest. It returns an error when it was not possible to update it.

--- a/PublicGitArchive/pga/cmd/get.go
+++ b/PublicGitArchive/pga/cmd/get.go
@@ -102,7 +102,7 @@ func downloadFilenames(ctx context.Context, dest, source FileSystem,
 
 	done := make(chan error)
 	for _, filename := range filenames {
-		filename := filepath.Join("siva", "latest", filename[:2], filename)
+		filename := filepath.Join("siva", pgaVersion, filename[:2], filename)
 		go func() {
 			select {
 			case <-tokens:

--- a/PublicGitArchive/pga/cmd/root.go
+++ b/PublicGitArchive/pga/cmd/root.go
@@ -24,6 +24,15 @@ For more info, check http://pga.sourced.tech/`,
 		if v {
 			logrus.SetLevel(logrus.DebugLevel)
 		}
+
+		pv, err := cmd.Flags().GetString("pga-version")
+		if err != nil {
+			return err
+		}
+
+		pgaVersion = pv
+		indexName = pv + ".csv.gz"
+
 		return nil
 	},
 }
@@ -37,7 +46,13 @@ func Execute() {
 	}
 }
 
+var (
+	indexName  string
+	pgaVersion string
+)
+
 func init() {
 	RootCmd.Flags().BoolP("toggle", "t", false, "help message for toggle")
 	RootCmd.PersistentFlags().BoolP("verbose", "v", false, "log more information")
+	RootCmd.PersistentFlags().StringVar(&pgaVersion, "pga-version", "latest", "pga version to be used")
 }


### PR DESCRIPTION
Closes #108 

Right now there is only one pga version so HTTP calls are hardcoded to be done to (for both either index or siva files):
```
http://pga.sourced.tech/csv/latest.csv.gz
http://pga.sourced.tech/siva/latest/xx/xx7303c49ac984a9fec60523f2d5297682e16646.siva
```

Adding the root flag `--pga-version` it allows you to select which version of the pga you want to work with, requesting for paths like:
```
http://pga.sourced.tech/csv/v1.csv.gz
http://pga.sourced.tech/siva/v1/xx/xx7303c49ac984a9fec60523f2d5297682e16646.siva
```

`latest` is set by default which is the only version works for the moment.