### PR TITLE
pga-create: add GO_TAGS = norwfs because it uses go-git v4.5.0

### DIFF
--- a/PublicGitArchive/pga-create/Makefile
+++ b/PublicGitArchive/pga-create/Makefile
@@ -3,6 +3,7 @@ PROJECT = pga-create
 COMMANDS = cmd/pga-create
 
 DOCKER_ORG = srcd
+GO_TAGS ?= norwfs
 
 # Including ci Makefile
 CI_REPOSITORY ?= https://github.com/src-d/ci.git


### PR DESCRIPTION
Signed-off-by: Manuel Carmona <manu.carmona90@gmail.com>