### PR TITLE
Add commit messages dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 
 **/.ci
 **/build
-
+__pycache__

--- a/CommitMessages/README.md
+++ b/CommitMessages/README.md
@@ -1,0 +1,64 @@
+Commit Messages ![size 46GB](https://img.shields.io/badge/size-46GB-green.svg)
+===============
+
+[Download link.](https://drive.google.com/open?id=1Os5MKKdpNUsWUN_vrP23PjsLCq-VpIev)
+
+1.3 billion commit messages extracted from [GHTorrent](https://ghtorrent.org) dumps.
+
+The dataset consists of 3 files:
+
+1. `commits.bin` - commit hashes, 24GB.
+2. `repos.txt.xz` - GitHub repository names, 5GB.
+3. `messages.txt.xz` - commit messages, 17GB.
+
+The precise number of commits is 1288456749. **There can be duplicate commits. Please contribute a deduplicated dataset if you can.**
+
+### Format
+
+1. `commits.bin` - continuous binary stream, 20 bytes per commit hash. The hashes are random by definition, so it makes no sense to compress this file.
+2. `repos.txt.xz` - strings separated by `\0` - NULL character, xz-compressed. The order matches `commits.bin`. There is a trailing '\0'.
+3. `messages.txt.xz` - strings separated by `\0`, xz-compressed. The order matches `commits.bin`. There is a trailing '\0'.
+
+### Sample code
+
+Python:
+```python
+import lzma
+from custom_newline import CustomNewlineReader
+
+with open("commits.bin", "rb") as commf:
+    with CustomNewlineReader(xz.open("repos.txt.xz"), b"\0") as reposf:
+        with CustomNewlineReader(xz.open("messages.txt.xz"), b"\0") as msgf:
+            for msg, repo in zip(msgf, reposf):
+                commit = commf.read(20).hex()
+                print(commit, repo.decode(), msg.decode())
+                
+```
+
+[`custom_newline.py`](custom_newline.py) is included into this repository.
+
+### Origin
+
+GHTorrent MongoDB dumps before 2019-03-18. The command to generate the dataset was:
+
+```
+(
+  for dd in 2019-03-17 2019-03-16 ... 2015-12-01; do
+    wget -O - http://ghtorrent-downloads.ewi.tudelft.nl/mongo-daily/mongo-dump-$dd.tar.gz |
+    tar -xzO dump/github/commits.bson
+  done
+  for dd in 2015-12-01 2015-10-03 2015-08-03; do
+    wget -O - http://ghtorrent-downloads.ewi.tudelft.nl/mongo-full/commits-dump.$dd.tar.gz |
+    tar -xzO dump/github/commits.bson
+  done
+  wget -O - http://ghtorrent-downloads.ewi.tudelft.nl/mongo-full/commits-1-dump.2015-08-04.tar.gz |
+  tar -xzO dump/github/commits.bson
+) | python3 parse.py
+```
+
+`2019-03-17 2019-03-16 ... 2015-12-01` are the dump dates from [ghtorrent.org/downloads.html](http://ghtorrent.org/downloads.html).
+[`parse.py`](parse.py) is included into this repository.
+
+### License
+
+[Open Data Commons Open Database License (ODbL)](https://opendatacommons.org/licenses/odbl/)

--- a/CommitMessages/custom_newline.py
+++ b/CommitMessages/custom_newline.py
@@ -1,0 +1,31 @@
+class CustomNewlineReader:
+    def __init__(self, fileobj, newline):
+        self.fileobj = fileobj
+        if len(newline) != 1:
+            raise ValueError("newline must be exactly one character long")
+        self.newline = newline
+        self.buffer_size = 1 << 18
+        self._chunks = []
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._chunks:
+            return self._chunks.pop(0)
+        read = self.fileobj.read
+        buffer = read(self.buffer_size)
+        if not buffer:
+            raise StopIteration
+        extra = bytearray()
+        b = buffer[-1:]
+        while b != self.newline:
+            b = read(1)
+            if not b:
+                break
+            extra.append(b[0])
+        buffer += extra
+        self._chunks = buffer.split(self.newline)
+        if b == self.newline:
+            self._chunks = self._chunks[:-1]
+        return next(self)

--- a/CommitMessages/parse.py
+++ b/CommitMessages/parse.py
@@ -1,0 +1,16 @@
+import lzma
+import sys
+
+import bson  # from PyMongo
+
+
+with open("commits.bin", "wb") as commits:
+    with lzma.open("repos.txt.xz", "wb") as repos:
+        with lzma.open("messages.txt.xz", "wb") as messages:
+            for obj in bson.decode_file_iter(sys.stdin.buffer, codec_options=bson.CodecOptions(
+                    unicode_decode_error_handler="ignore")):
+                commits.write(bytes.fromhex(obj["sha"]))
+                repos.write(obj["commit"]["url"][29:-53].encode())
+                repos.write(b"\0")
+                messages.write(obj["commit"]["message"].encode(errors="ignore"))
+                messages.write(b"\0")

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ This repository contains all the needed tools and scripts to reproduce the datas
 - Size: 1.6GB
 - Description: 25.3 million GitHub PR review comments since January 2015 till December 2018.
 
+### Commit messages
+
+- [Commit messages](CommitMessages)
+- Size: 46GB
+- Description: 1.3 billion GitHub commit messages till March 2019.
+
 ## Contributions
 
 Contributions are very welcome, please see [CONTRIBUTING.md](CONTRIBUTING.md) and [code of conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Signed-off-by: Vadim Markovtsev <vadim@sourced.tech>

Preventing merge: it appeared that the previous "full" GHTorrent dumps are still incremental, so I have to download them and extend the dataset.