### PR TITLE
pga-create: bug fixing and docker image update

### DIFF
--- a/PublicGitArchive/pga-create/Dockerfile
+++ b/PublicGitArchive/pga-create/Dockerfile
@@ -1,7 +1,7 @@
 #==========================
 # Stage 1: build pga-create
 #==========================
-FROM golang:1.12.3-alpine3.9 AS builder
+FROM golang:1.12.4-alpine3.9 AS builder
 
 RUN apk add --no-cache dumb-init=1.2.2-r1 git
 
@@ -9,6 +9,7 @@ RUN apk add --no-cache dumb-init=1.2.2-r1 git
 ENV PGA_CREATE_REPO=github.com/src-d/datasets/PublicGitArchive/pga-create
 ENV PGA_CREATE_PATH=$GOPATH/src/$PGA_CREATE_REPO
 COPY . ${PGA_CREATE_PATH}
+
 RUN go build -tags norwfs -o /bin/pga-create ${PGA_CREATE_PATH}/cmd/pga-create
 
 RUN cp ${PGA_CREATE_PATH}/select-repos.sh /bin/select-repos && chmod +x /bin/select-repos
@@ -17,7 +18,7 @@ RUN cp ${PGA_CREATE_PATH}/index-repos.sh /bin/index-repos && chmod +x /bin/index
 #=====================================================
 # Stage 2: copy binaries and set environment variables
 #=====================================================
-FROM alpine:3.9.2
+FROM alpine:3.9.3
 
 COPY --from=builder /bin/pga-create /bin/*-repos /usr/bin/dumb-init /bin/
 

--- a/PublicGitArchive/pga-create/cmd/pga-create/discover.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/discover.go
@@ -320,8 +320,7 @@ func writeData(w io.Writer, stars map[uint32]uint32, reposPath string) {
 	})
 
 	cw := csv.NewWriter(w)
-	headers := []string{"repository", "stars"}
-	if err := cw.Write(headers); err != nil {
+	if err := writeCSVHeaders(cw); err != nil {
 		fail("writing to repositories file", err)
 	}
 
@@ -345,4 +344,9 @@ func writeData(w io.Writer, stars map[uint32]uint32, reposPath string) {
 	if err := cw.Error(); err != nil {
 		fail("writing to repositories file", err)
 	}
+}
+
+func writeCSVHeaders(w *csv.Writer) error {
+	headers := []string{"repository", "stars"}
+	return w.Write(headers)
 }

--- a/PublicGitArchive/pga-create/cmd/pga-create/select.go
+++ b/PublicGitArchive/pga-create/cmd/pga-create/select.go
@@ -70,6 +70,9 @@ func selectRepos(params selectionParameters) {
 		}()
 
 		idxw = csv.NewWriter(gzw)
+		if err := writeCSVHeaders(idxw); err != nil {
+			fail("writing csv headers", err)
+		}
 	}
 
 	r := csv.NewReader(gzf)

--- a/PublicGitArchive/pga-create/process.go
+++ b/PublicGitArchive/pga-create/process.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/erizocosmico/gocloc"
 	"github.com/sirupsen/logrus"
+
 	"gopkg.in/src-d/core-retrieval.v0"
 	"gopkg.in/src-d/core-retrieval.v0/model"
 	"gopkg.in/src-d/core-retrieval.v0/repository"
@@ -486,6 +487,8 @@ func sivaFiles(inits map[model.SHA1]struct{}) []string {
 var regSivaDir = regexp.MustCompile(`\b([0-9a-f]{40})_[0-9]{19}\b`)
 
 func sivaSize(init string) (int64, error) {
+	// siva's temporary files path looks like:
+	// /tmp/sourced/123456789/transactioner/7a80dfe1684664cefd2923bdbb329dcb9a48dc4f_1551878586555302343/siva
 	tmpFS := core.TemporaryFilesystem()
 	info, err := tmpFS.ReadDir("")
 	if err != nil {
@@ -496,7 +499,7 @@ func sivaSize(init string) (int64, error) {
 		return -1, fmt.Errorf("tmp directory wasn't in a clean status")
 	}
 
-	tmp := filepath.Join(info[0].Name(), "transactioner")
+	tmp := info[0].Name()
 	info, err = tmpFS.ReadDir(tmp)
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
- Update base images used by the Dockerfile.
- `select` command now write csv headers to the generated file. From the indexer side these headers were read and discarded but before weren't written in the select step.
- fix the siva temporal path used in the `sivaSize` function.