### PR TITLE
pga-create: fix clean temp siva files on indexer error

### DIFF
--- a/PublicGitArchive/pga-create/process.go
+++ b/PublicGitArchive/pga-create/process.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"sync"
@@ -339,6 +340,7 @@ func (p *processor) process() (*repositoryData, error) {
 	data.SivaFiles = sivaFiles(inits)
 	data.Size = sumOfSivaSizes
 
+	debug.FreeOSMemory()
 	return data, nil
 }
 


### PR DESCRIPTION
- fix clean temp siva files on indexer error
- force free memory after the indexer analyzes a repository.