### PR TITLE
Support the UAST dataset in `pga` tool

### DIFF
--- a/PublicGitArchive/pga/pga/pga.go
+++ b/PublicGitArchive/pga/pga/pga.go
@@ -63,6 +63,7 @@ func ForEachRepository(ctx context.Context, r *csv.Reader, dataset Dataset, filt
 // Datasets is a slice containing Dataset objects on which we can apply the `get` and `list` commands.
 var Datasets = []Dataset{
 	&SivaDataset{},
+	&UastDataset{},
 }
 
 type badHeaderLengthError struct {

--- a/PublicGitArchive/pga/pga/uast.go
+++ b/PublicGitArchive/pga/pga/uast.go
@@ -1,0 +1,126 @@
+package pga
+
+const (
+	uastHeaderURL = iota
+	uastHeaderFilenames
+	uastHeaderFileCount
+	uastHeaderSize
+	uastHeaderFileExtractionRate
+	uastHeaderByteExtractionRate
+	uastHeaderLangs
+	uastHeaderLangsFileCount
+	uastHeaderLangsByteCount
+	uastHeaderLangsFileExtractionRate
+	uastHeaderLangsByteExtractionRate
+)
+
+var uastCSVHeaders = []string{
+	uastHeaderURL:                     "URL",
+	uastHeaderFilenames:               "PARQUET_FILENAMES",
+	uastHeaderFileCount:               "FILE_COUNT",
+	uastHeaderSize:                    "SIZE",
+	uastHeaderFileExtractionRate:      "FILE_EXTRACT_RATE",
+	uastHeaderByteExtractionRate:      "BYTE_EXTRACT_RATE",
+	uastHeaderLangs:                   "LANGS",
+	uastHeaderLangsFileCount:          "LANGS_FILE_COUNT",
+	uastHeaderLangsByteCount:          "LANGS_BYTE_COUNT",
+	uastHeaderLangsFileExtractionRate: "LANGS_FILE_EXTRACT_RATE",
+	uastHeaderLangsByteExtractionRate: "LANGS_BYTE_EXTRACT_RATE",
+}
+
+// UastRepository contains the data from a row of the CSV index
+type UastRepository struct {
+	URL              string   `json:"url"`              // URL of the repository.
+	ParquetFilenames []string `json:"parquetFilenames"` // Parquet filenames.
+	Size             int64    `json:"size"`             // Sum of the files sizes.
+
+	// Stats per language
+	Languages                   []string  `json:"langs"`                // Languages found in the repository.
+	LanguagesFileCount          []int64   `json:"langsFileCount"`       // Number of files in the language in the same index.
+	LanguagesByteCount          []int64   `json:"langsByteCount"`       // Number of bytes for the language in same index.
+	LanguagesFileExtractionRate []float64 `json:"langsFileExtractRate"` // Ratio of files extracted and converted to UAST in the repository per language.
+	LanguagesByteExtractionRate []float64 `json:"langsByteExtractRate"` // Ratio of bytes extracted and converted to UAST in the repository per language.
+
+	// Global stats
+	Files              int64   `json:"fileCount"`       // Number of files in the repository.
+	FileExtractionRate float64 `json:"fileExtractRate"` // Ratio of files extracted and converted to UAST in the repository.
+	ByteExtractionRate float64 `json:"byteExtractRate"` // Ratio of bytes extracted and converted to UAST in the repository.
+}
+
+// ToCSV returns a slice of strings corresponding to the CSV representation of the repository.
+func (r *UastRepository) ToCSV() []string {
+	return []string{
+		uastHeaderURL:                     r.URL,
+		uastHeaderFilenames:               formatStringList(r.ParquetFilenames),
+		uastHeaderFileCount:               formatInt(r.Files),
+		uastHeaderSize:                    formatInt(r.Size),
+		uastHeaderFileExtractionRate:      formatFloat(r.FileExtractionRate),
+		uastHeaderByteExtractionRate:      formatFloat(r.ByteExtractionRate),
+		uastHeaderLangs:                   formatStringList(r.Languages),
+		uastHeaderLangsFileCount:          formatIntList(r.LanguagesFileCount),
+		uastHeaderLangsByteCount:          formatIntList(r.LanguagesByteCount),
+		uastHeaderLangsFileExtractionRate: formatFloatList(r.LanguagesFileExtractionRate),
+		uastHeaderLangsByteExtractionRate: formatFloatList(r.LanguagesByteExtractionRate),
+	}
+}
+
+// GetURL returns the string corresponding to the URL of the repository.
+func (r *UastRepository) GetURL() string {
+	return r.URL
+}
+
+// GetLanguages returns a slice of strings corresponding to the languages found in the repository.
+func (r *UastRepository) GetLanguages() []string {
+	return r.Languages
+}
+
+// GetFilenames returns a slice of strings corresponding to the filenames found in the repository.
+func (r *UastRepository) GetFilenames() []string {
+	return r.ParquetFilenames
+}
+
+// UastDataset provides iteration over the SivaRepositories.
+type UastDataset struct{}
+
+// Name returns the name of the dataset
+func (UastDataset) Name() string {
+	return "uast"
+}
+
+// ReadHeader reads the header of the CSV index.
+func (dataset *UastDataset) ReadHeader(columnNames []string) error {
+	length := len(columnNames)
+	expected := len(uastCSVHeaders)
+	if length != expected {
+		return &badHeaderLengthError{
+			length:      length,
+			expectedMin: expected,
+			expectedMax: expected,
+		}
+	}
+
+	for i, h := range columnNames {
+		if h != uastCSVHeaders[i] {
+			return &badHeaderColumnError{expected: uastCSVHeaders[i], index: i, col: h}
+		}
+	}
+	return nil
+}
+
+// RepositoryFromTuple returns a UastRepository from a slice of strings corresponding to it's CSV representation.
+func (dataset *UastDataset) RepositoryFromTuple(cols []string) (repo Repository, err error) {
+	p := parser{cols: cols, csvHeaders: &uastCSVHeaders}
+	return &UastRepository{
+		URL:                         p.readString(uastHeaderURL),
+		ParquetFilenames:            p.readStringList(uastHeaderFilenames),
+		Files:                       p.readInt(uastHeaderFileCount),
+		Size:                        p.readInt(uastHeaderSize),
+		FileExtractionRate:          p.readFloat(uastHeaderFileExtractionRate),
+		ByteExtractionRate:          p.readFloat(uastHeaderByteExtractionRate),
+		Languages:                   p.readStringList(uastHeaderLangs),
+		LanguagesFileCount:          p.readIntList(uastHeaderLangsFileCount),
+		LanguagesByteCount:          p.readIntList(uastHeaderLangsByteCount),
+		LanguagesFileExtractionRate: p.readFloatList(uastHeaderLangsFileExtractionRate),
+		LanguagesByteExtractionRate: p.readFloatList(uastHeaderLangsByteExtractionRate),
+	}, p.err
+}


### PR DESCRIPTION
For more info on context see [this ml issue](https://github.com/src-d/ml-backlog/issues/97) and  [this infra issue](https://github.com/src-d/infrastructure/issues/1170).

This PR only deals with the first dataset, ie the UASTs extracted from the HEAD of PGAv2, and stored as parquet. It does not contain yet any documentation, apart from in side the code - and I did not put much effort into the comments, as I wasn't sure the logic would be kept. Anyway here's a run down of the changes:

**commit 1**: typos

**commit 2 and 3**: 

Add `uast_dataset.go` and `siva_dataset.go`. Basically, since both datasets are comprised of individual files I wanted to keep the same commands for listing and downloading, so I had to abstract all the logic from `IndexToCSV`, RepositoryFromCSV and `ToCSV`, as well as the schemas. In order to do that I:
- transformed `Repository` in an interface with `ToCSV` as it's method
- added a Dataset interface with `IndexFromCSV` as it's method
- renamed `RepositoryFromCSV` to be dataset specific, and handled by dataset specific index - as we don't need to deal with legacy indexes for the new dataset.
- I then added schemas for both datasets (had to rename most variables of the Siva dataset)
- added getters for the abstract `Repository`'s `URL`, `Languages` and `Siva`/`Parquet` `Filenames`, used in other places.

**commit 4**  

Following the previous changes, I basically removed all code I move to `siva_dataset`, added parsers/formatter for `floats` with 2 point precision as well as a `csvColumn` field, and created a mapping for datasets. Also modified the types as `Repository` is now an interface, and (I think) can't be pointed to the same.

**commit 5**

Now using getters in `filters.go`, and updated typing.

**commit 6**

Added a handler for the `datasetName` arg now used in `get`/`list`.

**commit 7**

Updated commands to the new structure, more of the same: getters, typing, now using `Dataset` and `Dataset` handler.


**Note:** I was thinking of adding a parquet command to dump listing of individual parquet files, as well as some additional filters to be used only by the `uast` dataset, related to the extraction rate. What do you think ?